### PR TITLE
Repeating server request in case of internet connection issues

### DIFF
--- a/lib/post.js
+++ b/lib/post.js
@@ -3,6 +3,8 @@
 const querystring = require('querystring');
 const https = require('https');
 
+const ETIMEDOUT = 'Request timed out.';
+
 function post(params, callback) {
   const form = querystring.stringify(params.form);
   const options = {
@@ -44,11 +46,31 @@ function post(params, callback) {
 
   req.on('timeout', function() {
     req.abort();
-    callback(Error('Request timed out.'));
+    callback(Error(ETIMEDOUT));
   });
 
   req.write(form);
   req.end();
 }
 
-module.exports = post;
+function postRetryingDecorator(params, callback) {
+  let tryNumber = 1;
+  let callbackOrigin = callback;
+  let paramsOrigin = params;
+  let requestLimit = params.requestLimit || 2;
+  let timeout = params.timeout || 500;
+
+  let callbackMock = function(err) {
+    if (err && err.message == ETIMEDOUT && tryNumber <= requestLimit) {
+      tryNumber++;
+      setTimeout(function() { post(paramsOrigin, callbackMock); }, timeout);
+      return;
+    }
+
+    callbackOrigin.apply(this, arguments);
+  };
+
+  post(params, callbackMock);
+}
+
+module.exports = postRetryingDecorator;

--- a/lib/yandex-speller.js
+++ b/lib/yandex-speller.js
@@ -104,6 +104,8 @@ function prepareSettings(settings) {
       format: settings.format || 'plain',
       lang: settings.lang || 'en,ru',
       options: prepareOptions(settings.options),
+      requestLimit: settings.requestLimit || 2,
+      timeout: settings.timeout || 500
     };
 }
 
@@ -111,6 +113,8 @@ function prepareSettings(settings) {
  * @typedef {Object} Settings
  * @param {string} [format] Text format: plain or html.
  * @param {string|Array} [lang] Language: en, ru or uk.
+ * @param {number} [requestLimit] Request repeat count in case internet connection issues.
+ * @param {number} [timeout] Timeout between request repeats in milliseconds.
  * @param {Object} [options]
  * @param {boolean} [options.ignoreUppercase] Ignore words written in capital letters.
  * @param {boolean} [options.ignoreDigits] Ignore words with numbers, such as "avp17h4534".


### PR DESCRIPTION
There are two additional fields in settings param in '_checkText(s)_' functions:

_requestLimit_ - Request repeat count in case internet connection issues. Default value - 2.
_timeout_ - Timeout between request repeats in milliseconds. Default value - 500.

This is my first pull request in open source, so don't judge strictly.

