### PR TITLE
Update post.js

### DIFF
--- a/lib/post.js
+++ b/lib/post.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const querystring = require('querystring');
-const http = require('http');
+const https = require('https');
 
 const ETIMEDOUT = 'Request timed out.';
 
@@ -10,7 +10,7 @@ function post(params, callback) {
     const options = {
         host: params.host,
         path: params.path,
-        port: 80,
+        port: 443,
         method: 'POST',
         headers: {
             'Content-Type': 'application/x-www-form-urlencoded',
@@ -18,7 +18,7 @@ function post(params, callback) {
         }
     };
 
-    let req = http.request(options, function(res) {
+    let req = https.request(options, function(res) {
         let textBuffer = '';
 
         res.setEncoding('utf8');


### PR DESCRIPTION
http сейчас выдает 307 код (редирект), поэтому падает спелчекер, сменил на https

```bash
curl -v 'http://speller.yandex.net/services/spellservice/checkTexts' --data-raw 'text=%D0%9F%D1%80%D0%B0%D0%B2%D0%B5%D1%80%D0%BA%D0%B0&lang=&options=&format='
```